### PR TITLE
"lava-test-case" changed [REVPI-2739]

### DIFF
--- a/automated/device-config/core/config_loader.sh
+++ b/automated/device-config/core/config_loader.sh
@@ -5,7 +5,6 @@ cp _config.rsc /var/www/revpi/pictory/projects/_config.rsc
 if [ $? -ne 0 ]
 then
     lava-test-case "$TEST_CASE_NAME" --result fail
-    lava-test-raise "Device configuration ERROR - _config.rsc not found?"
 else
     lava-test-case "$TEST_CASE_NAME" --result pass
 fi

--- a/automated/device-config/core/config_loader.sh
+++ b/automated/device-config/core/config_loader.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 TEST_CASE_NAME=$(basename "$0" .sh)
 
-cp _config.rsc /var/www/revpi/pictory/projects/_config.rsc
-if [ $? -ne 0 ]
+if ! cp _config.rsc /var/www/revpi/pictory/projects/_config.rsc;
 then
     lava-test-case "$TEST_CASE_NAME" --result fail
 else

--- a/automated/device-config/core/config_loader.sh
+++ b/automated/device-config/core/config_loader.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
+TEST_CASE_NAME=$(basename "$0" .sh)
 
 cp _config.rsc /var/www/revpi/pictory/projects/_config.rsc
 if [ $? -ne 0 ]
 then
-    lava-test-case logfile --result fail
+    lava-test-case "$TEST_CASE_NAME" --result fail
     lava-test-raise "Device configuration ERROR - _config.rsc not found?"
 else
-    lava-test-case logfile --result pass
+    lava-test-case "$TEST_CASE_NAME" --result pass
 fi
 
 chown www-data:www-data _config.rsc

--- a/automated/linux/basic-tests/basic-test-0002_repo-script.sh
+++ b/automated/linux/basic-tests/basic-test-0002_repo-script.sh
@@ -17,4 +17,4 @@ lava-test-case "$TEST_CASE_NAME-example-fail" --result fail
 # Use: lava-test-raise "message from test shell".
 # The rest of the test job will not run.
 # Example:
-lava-test-raise "Error title. State of Job will show as Incompleted.FAIL"
+#lava-test-raise "Error title. State of Job will show as Incompleted.FAIL"

--- a/automated/linux/basic-tests/basic-test-0002_repo-script.sh
+++ b/automated/linux/basic-tests/basic-test-0002_repo-script.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
+TEST_CASE_NAME=$(basename "$0" .sh)
 
 echo "Test echo with script - LAVA for RevPi Devices"
 
 # Each test case has a name and a result.
 # Optionally, test cases can have measurements and units.
 # lava-test-case will not halt the test job immediately if result fail.
-lava-test-case logfile --result pass
-lava-test-case logfile --result fail
+lava-test-case "$TEST_CASE_NAME-example-pass" --result pass
+lava-test-case "$TEST_CASE_NAME-example-fail" --result fail
 
 # Custom scripts should check the return code of setup operations
 # and use lava-test-raise to halt the test job immediately

--- a/automated/linux/ethernet/test-eth-ethtool.sh
+++ b/automated/linux/ethernet/test-eth-ethtool.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source "../test_format.sh"
+TEST_CASE_NAME=$(basename "$0" .sh)
 
 # Waiting for Parameter:
 #1- Speed: 100Mb/s
@@ -22,9 +22,9 @@ do
 	echo $RET_ETHTOOL | grep -E -o $i
 	if [ "$?" == 0 ]
 	then
-		lava-test-case logfile --result pass
+		lava-test-case "$TEST_CASE_NAME-$i" --result pass
 	else
-		lava-test-case logfile --result fail
-		lava-test-raise "Test ethtool FAIL - " $r
+		lava-test-case "$TEST_CASE_NAME-$i" --result fail
+		lava-test-raise "$TEST_CASE_NAME FAIL - " $r
 	fi
 done

--- a/automated/linux/ethernet/test-eth-ethtool.sh
+++ b/automated/linux/ethernet/test-eth-ethtool.sh
@@ -19,8 +19,7 @@ RET_ETHTOOL=$(ethtool eth0)
 
 for i in "${ETH_PARAM[@]}"
 do
-	echo $RET_ETHTOOL | grep -E -o $i
-	if [ "$?" == 0 ]
+	if echo "$RET_ETHTOOL" | grep -E -o "$i";
 	then
 		lava-test-case "$TEST_CASE_NAME-$i" --result pass
 	else

--- a/automated/linux/ethernet/test-eth-ethtool.sh
+++ b/automated/linux/ethernet/test-eth-ethtool.sh
@@ -25,6 +25,5 @@ do
 		lava-test-case "$TEST_CASE_NAME-$i" --result pass
 	else
 		lava-test-case "$TEST_CASE_NAME-$i" --result fail
-		lava-test-raise "$TEST_CASE_NAME FAIL - " $r
 	fi
 done

--- a/automated/linux/ethernet/test-eth-iperf3.sh
+++ b/automated/linux/ethernet/test-eth-iperf3.sh
@@ -7,16 +7,14 @@ IP_ATE="192.168.168.73"
 ip a show eth0 | grep inet
 
 echo "Connecting with ATE IP-Address: $IP_ATE"
-iperf3 -t 1800 -4 -c $IP_ATE -t 10
-if [ $? -eq 0 ]
+if iperf3 -t 1800 -4 -c $IP_ATE -t 10;
 then
     lava-test-case "$TEST_CASE_NAME-iperf3-1/2" --result pass
 else
     lava-test-case "$TEST_CASE_NAME-iperf3-1/2" --result fail
 fi
 
-iperf3 -t 1800 -4 -R -c $IP_ATE -t 10
-if [ $? -eq 0 ]
+if iperf3 -t 1800 -4 -R -c $IP_ATE -t 10;
 then
     lava-test-case "$TEST_CASE_NAME-iperf3-2/2" --result pass
 else

--- a/automated/linux/ethernet/test-eth-iperf3.sh
+++ b/automated/linux/ethernet/test-eth-iperf3.sh
@@ -1,34 +1,26 @@
 #!/bin/bash
-source "../test_format.sh"
+TEST_CASE_NAME=$(basename "$0" .sh)
 
 #Worker Host IP_ADDRESS!
 IP_ATE="192.168.168.73"
 
 ip a show eth0 | grep inet
 
-echo "$TXT_Section1"
 echo "Connecting with ATE IP-Address: $IP_ATE"
-echo "$TXT_Section1"
-echo "$TXT_Section2"
-echo "Start: 1/2"
-echo "$TXT_Section2"
 iperf3 -t 1800 -4 -c $IP_ATE -t 10
 if [ $? -eq 0 ]
 then
-    lava-test-case logfile --result pass
+    lava-test-case "$TEST_CASE_NAME-iperf3-1/2" --result pass
 else
-    lava-test-case logfile --result fail
-	lava-test-raise "Test iperf3 FAIL - Run server: $ iperf3 -s"
+    lava-test-case "$TEST_CASE_NAME-iperf3-1/2" --result fail
+	lava-test-raise "$TEST_CASE_NAME FAIL - Run server: $ iperf3 -s"
 fi
 
-echo "$TXT_Section2"
-echo "Start: 2/2"
-echo "$TXT_Section2"
 iperf3 -t 1800 -4 -R -c $IP_ATE -t 10
 if [ $? -eq 0 ]
 then
-    lava-test-case logfile --result pass
+    lava-test-case "$TEST_CASE_NAME-iperf3-2/2" --result pass
 else
-    lava-test-case logfile --result fail
-	lava-test-raise "Test iperf3 FAIL - Run server: $ iperf3 -s"
+    lava-test-case "$TEST_CASE_NAME-iperf3-2/2" --result fail
+	lava-test-raise "$TEST_CASE_NAME FAIL - Run server: $ iperf3 -s"
 fi

--- a/automated/linux/ethernet/test-eth-iperf3.sh
+++ b/automated/linux/ethernet/test-eth-iperf3.sh
@@ -13,7 +13,6 @@ then
     lava-test-case "$TEST_CASE_NAME-iperf3-1/2" --result pass
 else
     lava-test-case "$TEST_CASE_NAME-iperf3-1/2" --result fail
-	lava-test-raise "$TEST_CASE_NAME FAIL - Run server: $ iperf3 -s"
 fi
 
 iperf3 -t 1800 -4 -R -c $IP_ATE -t 10
@@ -22,5 +21,4 @@ then
     lava-test-case "$TEST_CASE_NAME-iperf3-2/2" --result pass
 else
     lava-test-case "$TEST_CASE_NAME-iperf3-2/2" --result fail
-	lava-test-raise "$TEST_CASE_NAME FAIL - Run server: $ iperf3 -s"
 fi

--- a/automated/linux/leds/test-leds1.sh
+++ b/automated/linux/leds/test-leds1.sh
@@ -14,8 +14,7 @@ declare -a LEDS_CORE_TREE=(
 RET_TREE=$(tree /sys/class/leds)
 for i in "${LEDS_CORE_TREE[@]}"
 do
-	echo "$RET_TREE" | grep -o "$i"
-	if [ "$?" == 0 ]
+	if echo "$RET_TREE" | grep -o "$i";
 	then
 		lava-test-case "$TEST_CASE_NAME-$i" --result pass
 	else

--- a/automated/linux/leds/test-leds1.sh
+++ b/automated/linux/leds/test-leds1.sh
@@ -20,6 +20,5 @@ do
 		lava-test-case "$TEST_CASE_NAME-$i" --result pass
 	else
 		lava-test-case "$TEST_CASE_NAME-$i" --result fail
-		lava-test-raise ""$TEST_CASE_NAME" FAIL $i"
 	fi
 done

--- a/automated/linux/leds/test-leds1.sh
+++ b/automated/linux/leds/test-leds1.sh
@@ -1,20 +1,19 @@
 #!/bin/bash
 TEST_CASE_NAME=$(basename "$0" .sh)
 
-declare -a LEDS_CORE_TREE=(
-	"├── a1_green -> ../../devices/platform/leds/leds/a1_green"
-	"├── a1_red -> ../../devices/platform/leds/leds/a1_red"
-	"├── a2_green -> ../../devices/platform/leds/leds/a2_green"
-	"├── a2_red -> ../../devices/platform/leds/leds/a2_red"
-	"├── default-on -> ../../devices/virtual/leds/default-on"
-	"├── mmc0 -> ../../devices/virtual/leds/mmc0"
-	"└── power_red -> ../../devices/platform/leds/leds/power_red"
+declare -a LEDS_CORE=(
+	"/sys/class/leds/a1_green"
+	"/sys/class/leds/a1_red"
+	"/sys/class/leds/a2_green"
+	"/sys/class/leds/a2_red"
+	"/sys/class/leds/default-on"
+	"/sys/class/leds/mmc0"
+	"/sys/class/leds/power_red"
 )
 
-RET_TREE=$(tree /sys/class/leds)
-for i in "${LEDS_CORE_TREE[@]}"
+for i in "${LEDS_CORE[@]}"
 do
-	if echo "$RET_TREE" | grep -o "$i";
+	if [[ -d "$i" ]];
 	then
 		lava-test-case "$TEST_CASE_NAME-$i" --result pass
 	else

--- a/automated/linux/leds/test-leds1.sh
+++ b/automated/linux/leds/test-leds1.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source "../test_format.sh"
+TEST_CASE_NAME=$(basename "$0" .sh)
 
 declare -a LEDS_CORE_TREE=(
 	"├── a1_green -> ../../devices/platform/leds/leds/a1_green"
@@ -17,9 +17,9 @@ do
 	echo "$RET_TREE" | grep -o "$i"
 	if [ "$?" == 0 ]
 	then
-		lava-test-case logfile --result pass
+		lava-test-case "$TEST_CASE_NAME-$i" --result pass
 	else
-		lava-test-case logfile --result fail
-		lava-test-raise "Test Leds1 FAIL $i"
+		lava-test-case "$TEST_CASE_NAME-$i" --result fail
+		lava-test-raise ""$TEST_CASE_NAME" FAIL $i"
 	fi
 done

--- a/automated/linux/leds/test-leds2.sh
+++ b/automated/linux/leds/test-leds2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source "../test_format.sh"
+TEST_CASE_NAME=$(basename "$0" .sh)
 
 #LED_TIME: LED on/off time.
 LED_TIME=1
@@ -20,4 +20,4 @@ do
 done
 
 # TODO: This test should be modified for external hardware...
-lava-test-case logfile --result pass
+lava-test-case "$TEST_CASE_NAME" --result pass

--- a/automated/linux/leds/test-leds2.sh
+++ b/automated/linux/leds/test-leds2.sh
@@ -13,10 +13,10 @@ LEDS_CORE=(
 
 for i in {0..3}
 do
-	echo ${LEDS_CORE[$i]}
-	echo 1 > /sys/class/leds/${LEDS_CORE[$i]}/brightness
+	echo "${LEDS_CORE[$i]}"
+	echo 1 > /sys/class/leds/"${LEDS_CORE[$i]}"/brightness
 	sleep $LED_TIME
-	echo 0 > /sys/class/leds/${LEDS_CORE[$i]}/brightness
+	echo 0 > /sys/class/leds/"${LEDS_CORE[$i]}"/brightness
 done
 
 # TODO: This test should be modified for external hardware...

--- a/automated/linux/piTest/test-PT-1.sh
+++ b/automated/linux/piTest/test-PT-1.sh
@@ -19,8 +19,7 @@ then
     fi
 
     #Check Module-UPDATE
-    piTest -d | grep $HW_UPDATE
-    if [ $? -eq 0 ]
+    if piTest -d | grep $HW_UPDATE;
     then
         lava-test-case "$TEST_CASE_NAME-$HW_UPDATE" --result fail
     fi

--- a/automated/linux/piTest/test-PT-1.sh
+++ b/automated/linux/piTest/test-PT-1.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+TEST_CASE_NAME=$(basename "$0" .sh)
 
 HW_UPDATE="The\sfirmware\sof\ssome\sI/O\smodules\smust\sbe\supdated."
 HW_NOT_PRESENT="Module\sis\sNOT\spresent"
@@ -12,19 +13,19 @@ then
 
     if [ $RET -ne 0 ]
     then
-        lava-test-case logfile --result pass
+        lava-test-case "$TEST_CASE_NAME-$HW_NOT_PRESENT-pass" --result pass
     else
-        lava-test-case logfile --result fail
-        lava-test-raise "Test PT-1 FAIL: DUT constellation must be checked! At least one module is NOT present, data is NOT available: $RET"
+        lava-test-case "$TEST_CASE_NAME-$HW_NOT_PRESENT-fail" --result fail
+        lava-test-raise "$TEST_CASE_NAME FAIL: DUT constellation must be checked! At least one module is NOT present, data is NOT available: $RET"
     fi
 
     #Check Module-UPDATE
     piTest -d | grep $HW_UPDATE
     if [ $? -eq 0 ]
     then
-        lava-test-case moduleUpdate --result fail
+        lava-test-case "$TEST_CASE_NAME-$HW_UPDATE" --result fail
     fi
 else
-    lava-test-case logfile --result fail
-    lava-test-raise "Test PT-1 FAIL: piTest -x ERROR: $RET"
+    lava-test-case "$TEST_CASE_NAME-piText-x-fail" --result fail
+    lava-test-raise "$TEST_CASE_NAME FAIL: piTest -x ERROR: $RET"
 fi

--- a/automated/linux/piTest/test-PT-1.sh
+++ b/automated/linux/piTest/test-PT-1.sh
@@ -16,7 +16,6 @@ then
         lava-test-case "$TEST_CASE_NAME-$HW_NOT_PRESENT-pass" --result pass
     else
         lava-test-case "$TEST_CASE_NAME-$HW_NOT_PRESENT-fail" --result fail
-        lava-test-raise "$TEST_CASE_NAME FAIL: DUT constellation must be checked! At least one module is NOT present, data is NOT available: $RET"
     fi
 
     #Check Module-UPDATE
@@ -27,5 +26,4 @@ then
     fi
 else
     lava-test-case "$TEST_CASE_NAME-piText-x-fail" --result fail
-    lava-test-raise "$TEST_CASE_NAME FAIL: piTest -x ERROR: $RET"
 fi

--- a/automated/linux/picontrol/test-pc-1.sh
+++ b/automated/linux/picontrol/test-pc-1.sh
@@ -1,19 +1,20 @@
 #!/bin/bash
+TEST_CASE_NAME=$(basename "$0" .sh)
 
 dmesg | grep -i picontrol
 if [ $? -eq 0 ]
 then
-	lava-test-case logfile --result pass
+	lava-test-case "$TEST_CASE_NAME-1" --result pass
 else
-	lava-test-case logfile --result fail
-	lava-test-raise "Test picontrol FAIL"
+	lava-test-case "$TEST_CASE_NAME-1" --result fail
+	lava-test-raise "$TEST_CASE_NAME FAIL"
 fi
 
 ls -l /dev/pi* | grep /dev/piControl0
 if [ $? -eq 0 ]
 then
-	lava-test-case logfile --result pass
+	lava-test-case "$TEST_CASE_NAME-2" --result pass
 else
-	lava-test-case logfile --result fail
-	lava-test-raise "Test picontrol FAIL"
+	lava-test-case "$TEST_CASE_NAME-2" --result fail
+	lava-test-raise "$TEST_CASE_NAME FAIL"
 fi

--- a/automated/linux/picontrol/test-pc-1.sh
+++ b/automated/linux/picontrol/test-pc-1.sh
@@ -7,7 +7,6 @@ then
 	lava-test-case "$TEST_CASE_NAME-1" --result pass
 else
 	lava-test-case "$TEST_CASE_NAME-1" --result fail
-	lava-test-raise "$TEST_CASE_NAME FAIL"
 fi
 
 ls -l /dev/pi* | grep /dev/piControl0
@@ -16,5 +15,4 @@ then
 	lava-test-case "$TEST_CASE_NAME-2" --result pass
 else
 	lava-test-case "$TEST_CASE_NAME-2" --result fail
-	lava-test-raise "$TEST_CASE_NAME FAIL"
 fi

--- a/automated/linux/picontrol/test-pc-1.sh
+++ b/automated/linux/picontrol/test-pc-1.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
 TEST_CASE_NAME=$(basename "$0" .sh)
 
-dmesg | grep -i picontrol
-if [ $? -eq 0 ]
+if dmesg | grep -i picontrol;
 then
 	lava-test-case "$TEST_CASE_NAME-1" --result pass
 else
 	lava-test-case "$TEST_CASE_NAME-1" --result fail
 fi
 
-ls -l /dev/pi* | grep /dev/piControl0
-if [ $? -eq 0 ]
+if ls -l /dev/piControl0*
 then
 	lava-test-case "$TEST_CASE_NAME-2" --result pass
 else

--- a/automated/linux/usb/test-usb-2.sh
+++ b/automated/linux/usb/test-usb-2.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+TEST_CASE_NAME=$(basename "$0" .sh)
 
 PATH_DEV="/dev/sda1"
 PATH_MOUNT="/mnt/lava_usb_test"
@@ -28,23 +29,23 @@ then
 
             if [ $? -eq 0 ]
             then
-                lava-test-case logfile --result pass
+                lava-test-case "$TEST_CASE_NAME-md5sum" --result pass
             else
-                lava-test-case logfile --result fail
-                lava-test-raise "Test usb-2 FAIL - Check md5sum failed"
+                lava-test-case "$TEST_CASE_NAME-md5sum" --result fail
+                lava-test-raise "$TEST_CASE_NAME FAIL - Check md5sum failed"
             fi
         else
-            lava-test-case logfile --result fail
-            lava-test-raise "Test usb-2 FAIL - Mount failed"
+            lava-test-case "$TEST_CASE_NAME-mount" --result fail
+            lava-test-raise "$TEST_CASE_NAME FAIL - Mount failed"
         fi
         cd /
         umount "$PATH_MOUNT"
         rm -r "$PATH_MOUNT"
     else
-        lava-test-case logfile --result fail
-        lava-test-raise "Test usb-2 FAIL - Flash disk cannot be formatted"
+        lava-test-case "$TEST_CASE_NAME-format" --result fail
+        lava-test-raise "$TEST_CASE_NAME FAIL - Flash disk cannot be formatted"
     fi
 else
-    lava-test-case logfile --result fail
-    lava-test-raise "Test usb-2 FAIL - Flash disk not found"
+    lava-test-case "$TEST_CASE_NAME-flash-disk" --result fail
+    lava-test-raise "$TEST_CASE_NAME FAIL - Flash disk not found"
 fi

--- a/automated/linux/usb/test-usb-2.sh
+++ b/automated/linux/usb/test-usb-2.sh
@@ -32,20 +32,16 @@ then
                 lava-test-case "$TEST_CASE_NAME-md5sum" --result pass
             else
                 lava-test-case "$TEST_CASE_NAME-md5sum" --result fail
-                lava-test-raise "$TEST_CASE_NAME FAIL - Check md5sum failed"
             fi
         else
             lava-test-case "$TEST_CASE_NAME-mount" --result fail
-            lava-test-raise "$TEST_CASE_NAME FAIL - Mount failed"
         fi
         cd /
         umount "$PATH_MOUNT"
         rm -r "$PATH_MOUNT"
     else
         lava-test-case "$TEST_CASE_NAME-format" --result fail
-        lava-test-raise "$TEST_CASE_NAME FAIL - Flash disk cannot be formatted"
     fi
 else
     lava-test-case "$TEST_CASE_NAME-flash-disk" --result fail
-    lava-test-raise "$TEST_CASE_NAME FAIL - Flash disk not found"
 fi

--- a/automated/linux/usb/test-usb-2.sh
+++ b/automated/linux/usb/test-usb-2.sh
@@ -4,30 +4,25 @@ TEST_CASE_NAME=$(basename "$0" .sh)
 PATH_DEV="/dev/sda1"
 PATH_MOUNT="/mnt/lava_usb_test"
 
-lsblk | grep sda1
-if [ $? -eq 0 ]
+if lsblk | grep sda1;
 then
     #Flash disk will be formatted
-    mke2fs -F -t ext4 "$PATH_DEV"
-
-    if [ $? -eq 0 ]
+    if mke2fs -F -t ext4 "$PATH_DEV";
     then
         if [ ! -d "$PATH_MOUNT" ]
         then
             mkdir "$PATH_MOUNT"
         fi
 
-        mount "$PATH_DEV" "$PATH_MOUNT"
-        if [ $? -eq 0 ]
+        if mount "$PATH_DEV" "$PATH_MOUNT";
         then
             dd if=/dev/urandom of=/tmp/testfile bs=512 count=1k
             md5sum /tmp/testfile > md5
 
             cp /tmp/testfile "$PATH_MOUNT"
             cp md5 "$PATH_MOUNT"
-            cd "$PATH_MOUNT" && md5sum -c md5
-
-            if [ $? -eq 0 ]
+            
+            if cd "$PATH_MOUNT" && md5sum -c md5;
             then
                 lava-test-case "$TEST_CASE_NAME-md5sum" --result pass
             else

--- a/automated/linux/usb/test-usb-3.sh
+++ b/automated/linux/usb/test-usb-3.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
+TEST_CASE_NAME=$(basename "$0" .sh)
 
 dd if=/dev/sda1 of=/dev/null status=progress conv=sync iflag=nocache oflag=nocache bs=1k count=1M
 RET=$?
 
 if [ $RET -eq 0 ]
 then
-    lava-test-case logfile --result pass
+    lava-test-case "$TEST_CASE_NAME" --result pass
 else
-    lava-test-case logfile --result fail
-    lava-test-raise "Test usb-3 FAIL - Unable to read from USB flash disk"
+    lava-test-case "$TEST_CASE_NAME" --result fail
+    lava-test-raise "$TEST_CASE_NAME FAIL - Unable to read from USB flash disk"
 fi

--- a/automated/linux/usb/test-usb-3.sh
+++ b/automated/linux/usb/test-usb-3.sh
@@ -9,5 +9,4 @@ then
     lava-test-case "$TEST_CASE_NAME" --result pass
 else
     lava-test-case "$TEST_CASE_NAME" --result fail
-    lava-test-raise "$TEST_CASE_NAME FAIL - Unable to read from USB flash disk"
 fi

--- a/automated/linux/usb/test-usb-4.sh
+++ b/automated/linux/usb/test-usb-4.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
+TEST_CASE_NAME=$(basename "$0" .sh)
 
 dd if=/dev/zero of=/dev/sda1 status=progress conv=sync iflag=nocache oflag=nocache bs=1k count=1M
 RET=$?
 
 if [ $RET -eq 0 ]
 then
-    lava-test-case logfile --result pass
+    lava-test-case "$TEST_CASE_NAME" --result pass
 else
-    lava-test-case logfile --result fail
-    lava-test-raise "Test usb-4 FAIL - Unable to write from USB flash disk"
+    lava-test-case "$TEST_CASE_NAME" --result fail
+    lava-test-raise "$TEST_CASE_NAME FAIL - Unable to write from USB flash disk"
 fi

--- a/automated/linux/usb/test-usb-4.sh
+++ b/automated/linux/usb/test-usb-4.sh
@@ -9,5 +9,4 @@ then
     lava-test-case "$TEST_CASE_NAME" --result pass
 else
     lava-test-case "$TEST_CASE_NAME" --result fail
-    lava-test-raise "$TEST_CASE_NAME FAIL - Unable to write from USB flash disk"
 fi

--- a/automated/revpi/pibridge/test-pb-1.sh
+++ b/automated/revpi/pibridge/test-pb-1.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+TEST_CASE_NAME=$(basename "$0" .sh)
+
 LOW=0
 HIGH=1
 
@@ -17,37 +19,25 @@ OUTPUT_R_2="O_3_i05"
 
 piTest_setIOValue()
 {
-  piTest -w $1,$2
+	piTest -w "$1","$2"
 }
 
 piTest_validateIOValue()
 {
-	RET=$(piTest -q -1 -r $1)
-	if [ $RET -ne $2 ]
+	RET=$(piTest -q -1 -r "$1")
+	if [ "$RET" -ne "$2" ]
 	then
-		lava-test-case logfile --result fail
-		lava-test-raise "Test pb-1 FAIL - piTest_validateIOValue()  $1: $RET"
+		lava-test-case "$TEST_CASE_NAME-$1" --result fail
+		lava-test-raise "Test $TEST_CASE_NAME FAIL - piTest_validateIOValue()  $1: $RET"
 	else
-		lava-test-case logfile --result pass
-	fi	
+		lava-test-case "$TEST_CASE_NAME-$1" --result pass
+	fi
 }
 
 #Set output LOW
 VALUE=$LOW
 piTest_setIOValue $OUTPUT_L_1 $VALUE
 piTest_setIOValue $OUTPUT_L_2 $VALUE
-piTest_setIOValue $OUTPUT_R_1 $VALUE
-piTest_setIOValue $OUTPUT_R_2 $VALUE
-sleep 1
-
-#Check inputs with LOW
-VALUE=$LOW
-piTest_validateIOValue $INPUT_L_1 $VALUE
-piTest_validateIOValue $INPUT_L_2 $VALUE
-piTest_validateIOValue $INPUT_R_1 $VALUE
-piTest_validateIOValue $INPUT_R_2 $VALUE
-
-#Set output HIGH
 VALUE=$HIGH
 piTest_setIOValue $OUTPUT_L_1 $VALUE
 piTest_setIOValue $OUTPUT_L_2 $VALUE

--- a/automated/revpi/pibridge/test-pb-1.sh
+++ b/automated/revpi/pibridge/test-pb-1.sh
@@ -28,7 +28,6 @@ piTest_validateIOValue()
 	if [ "$RET" -ne "$2" ]
 	then
 		lava-test-case "$TEST_CASE_NAME-$1" --result fail
-		lava-test-raise "Test $TEST_CASE_NAME FAIL - piTest_validateIOValue()  $1: $RET"
 	else
 		lava-test-case "$TEST_CASE_NAME-$1" --result pass
 	fi


### PR DESCRIPTION
In order to get a clear output in the results from "lava-test-case",  the test cases name has been changed. 

The new format used: 
TEST_CASE_NAME=$(basename "$0")
"$TEST_CASE_NAME-xxx"
"xxx" is used to better distinguish the test.