### PR TITLE
Add test und job for piBridge cycle time

### DIFF
--- a/automated/revpi/iocycle/pibridge-cycle-time
+++ b/automated/revpi/iocycle/pibridge-cycle-time
@@ -1,0 +1,149 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Test the cycle time of Revolution Pi piControl."""
+__author__ = "Sven Sager"
+__copyright__ = "Copyright (C) KUNBUS GmbH"
+__license__ = "GPLv2"
+__version__ = "1.0.3"
+
+import json
+import sys
+import textwrap
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from collections import OrderedDict
+from datetime import datetime
+from os import uname
+from queue import Queue
+from threading import Thread
+from time import time
+
+import revpimodio2
+
+# Generate command arguments of the program
+parser = ArgumentParser(
+    prog="test_cycle_time",
+    formatter_class=RawDescriptionHelpFormatter,
+    description=textwrap.dedent("""\
+        Measure the cycle time of piControl to update all IO modules.
+
+        The value of the variable `RevPiIOCycle` is read from the process
+        image every 10 milliseconds over the duration of the test. At the end,
+        a JSON object is output, which contains statistical data and
+        optionally all measurements with a time stamp.
+
+        The runtime status of this program goes to stderr. You will get the JSON
+        string in the end of measurement on stdout.
+        """),
+)
+parser.add_argument(
+    "-b", "--batch", dest="batch", action="store_true", default=False,
+    help="Print JSON string only (errors still written to stderr)",
+)
+parser.add_argument(
+    "-d", "--data", dest="data", action="store_true", default=False,
+    help="Add measured values with timestamps to JSON output",
+)
+parser.add_argument(
+    "-s", "--seconds", dest="seconds", type=int, default=30,
+    choices=range(1, 301), metavar="1-300",
+    help="Measurement time in seconds",
+)
+command_arguments = parser.parse_args()
+
+# Global variables
+que_measurement_data = Queue()
+"""Measurement values to pass to status display thread."""
+test_cycles = command_arguments.seconds * 100
+"""Number of cycles to reach the measurement time in 10 ms steps."""
+
+
+def measurement_cycle(ct: revpimodio2.Cycletools) -> revpimodio2.Cycletools:
+    """RevPiModIO measurement cycle at 10 ms."""
+    if ct.first:
+        ct.var.cycle_counter = 0
+        ct.var.measurement_data = {}
+
+    ct.var.cycle_counter += 1
+    cycle_time = ct.io.RevPiIOCycle()
+    ct.var.measurement_data[round(time(), 3)] = cycle_time
+
+    # Refresh display on first run and every 500 ms
+    if not command_arguments.batch and (ct.first or not ct.var.cycle_counter % 50):
+        # Dict values are mutable, the tuple is a copy for display thread
+        que_measurement_data.put_nowait(tuple(ct.var.measurement_data.values()))
+
+    if ct.last or ct.var.cycle_counter == test_cycles:
+        return ct
+
+
+def _status_display(*args, **kwargs) -> None:
+    """
+    Thread to calculate statistics of actual run and print on strerr.
+
+    We need this to not affect modio cycle time.
+    """
+    while True:
+        lst_measurement_data = que_measurement_data.get()
+        if not lst_measurement_data:
+            if not command_arguments.batch:
+                # Save last status line for user, because of tailing carriage return
+                sys.stderr.write("\n")
+            break
+
+        calculated_mean = sum(lst_measurement_data) / len(lst_measurement_data)
+
+        # Update the user info line and stay in that line with carriage return for next update
+        sys.stderr.write(
+            f"Cycles: {len(lst_measurement_data):4} | "
+            f"Min: {min(lst_measurement_data):4} | "
+            f"Mean: {calculated_mean:7.2f} | "
+            f"Max: {max(lst_measurement_data):4} | "
+            f"Remaining: {(test_cycles - len(lst_measurement_data)) // 100:4} sec."
+            "\r",
+        )
+
+
+# Fetch module info
+rpi = revpimodio2.RevPiModIO()
+lst_modules = [device.id for device in rpi.device]
+if not command_arguments.batch:
+    sys.stderr.write("Hardware configuration (left to right):\n")
+    for device_id in lst_modules:
+        sys.stderr.write(f"\t{device_id}\n")
+
+# Prepare and start satus display thread
+th_status_display = Thread(target=_status_display, daemon=True)
+th_status_display.start()
+
+# Use core module for measurement only. This reduces reads on piControl0.
+rpi = revpimodio2.RevPiModIOSelected(0, autorefresh=True, monitoring=True)
+rpi.handlesignalend()
+ct_result = rpi.cycleloop(measurement_cycle, 10)
+
+# Shut down display thread
+que_measurement_data.put_nowait(None)
+th_status_display.join()
+
+# Print JSON data to stdout
+uname_sysinfo = uname()
+dict_json_object = OrderedDict({
+    "time_local": datetime.now().isoformat(),
+    "duration_s": ct_result.var.cycle_counter / 100,
+    "cycles": ct_result.var.cycle_counter,
+    "min_ms": min(ct_result.var.measurement_data.values()),
+    "max_ms": max(ct_result.var.measurement_data.values()),
+    "mean_ms": round(
+        sum(ct_result.var.measurement_data.values())
+        / len(ct_result.var.measurement_data.values()),
+        2,
+    ),
+    "module_config": lst_modules,
+    "system": {
+        "kernel_version": uname_sysinfo.version,
+        "kernel_release": uname_sysinfo.release,
+        "machine": uname_sysinfo.machine,
+    },
+})
+if command_arguments.data:
+    dict_json_object["data_ms"] = ct_result.var.measurement_data
+sys.stdout.write(json.dumps(dict_json_object, indent=4) + "\n")

--- a/automated/revpi/iocycle/test-iocycle-2.sh
+++ b/automated/revpi/iocycle/test-iocycle-2.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+TEST_CASE_NAME=$(basename "$0" .sh)
+
+SHOW_JSON=$1
+MAX_MS=$2
+MEASUREMENT_TIME=$3
+
+if ! dpkg-query -W -f='${Status}\n' jq;
+then
+    apt-get update
+    apt-get install -y jq
+fi
+
+if [ $MEASUREMENT_TIME -ne 0 ] && [ $MEASUREMENT_TIME -le 300 ]
+then
+    RET_CYCLE_TIME=$(python3 pibridge-cycle-time -s${MEASUREMENT_TIME})
+else
+    RET_CYCLE_TIME=$(python3 pibridge-cycle-time)
+fi
+
+if [ "$SHOW_JSON" -ne 0 ]
+then
+    echo "$RET_CYCLE_TIME"
+fi
+
+if [ "$(echo "$RET_CYCLE_TIME" | jq '.max_ms')" -eq 0 ]
+then
+    lava-test-case "$TEST_CASE_NAME-max_ms-zero" --result fail
+else
+    if [ "$(echo "$RET_CYCLE_TIME" | jq '.max_ms')" -le "$MAX_MS" ]
+    then
+        lava-test-case "$TEST_CASE_NAME-max_ms" --result pass
+    else
+        lava-test-case "$TEST_CASE_NAME-max_ms" --result fail
+    fi
+fi

--- a/automated/revpi/iocycle/test-iocycle-2.yaml
+++ b/automated/revpi/iocycle/test-iocycle-2.yaml
@@ -1,0 +1,23 @@
+metadata:
+    name: Test IOCycle-2
+    format: "Lava-Test Test Definition 1.0"
+    description: "pibridge-cycle-time tool used for time-tests"
+    maintainer:
+        - r.gsponer@kunbus.com
+    os:
+        - raspian
+    scope:
+        - functional
+    devices:
+        - Core
+        - Core 3
+        - core 3+
+        - Core S
+        - Connect
+        - Connect+
+        - Connect S
+        - Connect SE
+run:
+    steps:
+        - cd automated/revpi/iocycle
+        - bash ./test-iocycle-2.sh ${SHOW_JSON} ${MAX_MS} ${MEASUREMENT_TIME}

--- a/automated/revpi/jobs-definition/connect/job-iocycle-2.yaml
+++ b/automated/revpi/jobs-definition/connect/job-iocycle-2.yaml
@@ -1,0 +1,39 @@
+device_type: RevPi_Connect
+job_name: RevPi_Connect - pibridge-cycle-time
+priority: medium
+visibility: public
+
+timeouts:
+  job:
+    minutes: 10
+  action:
+    minutes: 1
+  connection:
+    minutes: 2
+actions:
+- deploy:
+    timeout:
+      minutes: 4
+    to: ssh
+- boot:
+    method: ssh
+    connection: ssh
+    prompts: ["root@RevPi"]
+    timeout:
+      minutes: 2
+- test:
+    timeout:
+      minutes: 10
+    definitions:
+    - repository: https://github.com/RevolutionPi/LAVA-test-definitions.git
+      from: git
+      path: automated/device-config/connect/config_loader.yaml
+      name: config_loader
+    - repository: https://github.com/RevolutionPi/LAVA-test-definitions.git
+      from: git
+      path: automated/revpi/iocycle/test-iocycle-2.yaml
+      name: test-iocycle-2
+      params:
+        SHOW_JSON: 1
+        MAX_MS: 10
+        MEASUREMENT_TIME: 0

--- a/automated/revpi/jobs-definition/core/job-iocycle-2.yaml
+++ b/automated/revpi/jobs-definition/core/job-iocycle-2.yaml
@@ -1,0 +1,39 @@
+device_type: RevPi_Core
+job_name: RevPi_Core - pibridge-cycle-time
+priority: medium
+visibility: public
+
+timeouts:
+  job:
+    minutes: 10
+  action:
+    minutes: 1
+  connection:
+    minutes: 2
+actions:
+- deploy:
+    timeout:
+      minutes: 4
+    to: ssh
+- boot:
+    method: ssh
+    connection: ssh
+    prompts: ["root@RevPi"]
+    timeout:
+      minutes: 2
+- test:
+    timeout:
+      minutes: 10
+    definitions:
+    - repository: https://github.com/RevolutionPi/LAVA-test-definitions.git
+      from: git
+      path: automated/device-config/core/config_loader.yaml
+      name: config_loader
+    - repository: https://github.com/RevolutionPi/LAVA-test-definitions.git
+      from: git
+      path: automated/revpi/iocycle/test-iocycle-2.yaml
+      name: test-iocycle-2
+      params:
+        SHOW_JSON: 1
+        MAX_MS: 10
+        MEASUREMENT_TIME: 0


### PR DESCRIPTION
The tool "pibridge-cycle-time" is used to measure the cycle time on the piBridge. This is the time required for a complete update of the IO modules.

The idea is to use this tool for our LAVA-Tests with different Hardware constellations and different RevPi devices.

In this PR, a test for RevPi-Core and RevPi-Connect devices is presented.

Test for Core devices: [LAVA-Job-1142](https://lava.revpi.kunbus.com/scheduler/job/1142)
In this case the Tets fails because of the parameter "max_ms": [fail](https://lava.revpi.kunbus.com/scheduler/job/1142#results_12505)

I have included the file "pibridge-cycle-time", since the Benchmark-Repository is private... Maybe this can be changed and then this file will not be needed.

Ideas or suggestions are welcome!