### PR TITLE
Add and Update health checks Jobs

### DIFF
--- a/automated/health-checks/health-check_Core_SE.yaml
+++ b/automated/health-checks/health-check_Core_SE.yaml
@@ -1,0 +1,43 @@
+device_type: Core_SE
+job_name: Core_SE - Standard health check
+priority: medium
+visibility: public
+
+timeouts:
+  job:
+    minutes: 5
+  action:
+    minutes: 1
+  connection:
+    minutes: 2
+
+actions:
+- deploy:
+    timeout:
+      # this is a health check, so no flashing or other time-intensive tasks
+      # need to be executed
+      minutes: 1
+    to: ssh
+
+- boot:
+    method: ssh
+    connection: ssh
+    # it is assumed that the revpi is in a working state for the health check,
+    # so the prompt should be set correctly (i.e. the hostname is correct)
+    prompts: ["root@RevPi[0-9]+:"]
+    timeout:
+      minutes: 1
+
+- test:
+    timeout:
+      # the actual test for the health check is very basic and tests for dmesg
+      # warnings or errors, cpu load, free memory, free disk space, and
+      # internet connectivity. this should be doable in 1 minute
+      minutes: 1
+    definitions:
+    - name: health-check-test
+      repository: https://github.com/RevolutionPi/LAVA-test-definitions.git
+      from: git
+      path: automated/health-checks/tests/health-check-test.yaml
+      params:
+        DUT: "Core_SE"

--- a/automated/health-checks/health-check_RevPi_Connect.yaml
+++ b/automated/health-checks/health-check_RevPi_Connect.yaml
@@ -1,0 +1,41 @@
+device_type: RevPi_Connect
+job_name: RevPi_Connect - Standard health check
+priority: medium
+visibility: public
+
+timeouts:
+  job:
+    minutes: 5
+  action:
+    minutes: 1
+  connection:
+    minutes: 2
+    
+actions:
+- deploy:
+    timeout:
+      minutes: 4
+    to: ssh
+- boot:
+    method: ssh
+    connection: ssh
+    prompts: ["root@RevPi"]
+    timeout:
+      minutes: 2
+
+- test:
+    timeout:
+      minutes: 5
+    definitions:
+    - repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: worker-device-test
+          description: "Simple test if the test will be executed on given devices on a specific worker"
+        run:
+          steps:
+          - lava-test-case test1-pass --result pass
+          - lava-test-case test2-pass --result pass
+      from: inline
+      name: worker-device-test
+      path: inline/worker-device-test.yaml

--- a/automated/health-checks/health-check_RevPi_Connect.yaml
+++ b/automated/health-checks/health-check_RevPi_Connect.yaml
@@ -10,32 +10,34 @@ timeouts:
     minutes: 1
   connection:
     minutes: 2
-    
+
 actions:
 - deploy:
     timeout:
-      minutes: 4
+      # this is a health check, so no flashing or other time-intensive tasks
+      # need to be executed
+      minutes: 1
     to: ssh
+
 - boot:
     method: ssh
     connection: ssh
-    prompts: ["root@RevPi"]
+    # it is assumed that the revpi is in a working state for the health check,
+    # so the prompt should be set correctly (i.e. the hostname is correct)
+    prompts: ["root@RevPi[0-9]+:"]
     timeout:
-      minutes: 2
+      minutes: 1
 
 - test:
     timeout:
-      minutes: 5
+      # the actual test for the health check is very basic and tests for dmesg
+      # warnings or errors, cpu load, free memory, free disk space, and
+      # internet connectivity. this should be doable in 1 minute
+      minutes: 1
     definitions:
-    - repository:
-        metadata:
-          format: Lava-Test Test Definition 1.0
-          name: worker-device-test
-          description: "Simple test if the test will be executed on given devices on a specific worker"
-        run:
-          steps:
-          - lava-test-case test1-pass --result pass
-          - lava-test-case test2-pass --result pass
-      from: inline
-      name: worker-device-test
-      path: inline/worker-device-test.yaml
+    - name: health-check-test
+      repository: https://github.com/RevolutionPi/LAVA-test-definitions.git
+      from: git
+      path: automated/health-checks/tests/health-check-test.yaml
+      params:
+        DUT: "Connect"

--- a/automated/health-checks/health-check_RevPi_Core.yaml
+++ b/automated/health-checks/health-check_RevPi_Core.yaml
@@ -1,0 +1,41 @@
+device_type: RevPi_Core
+job_name: RevPi_Core - Standard health check
+priority: medium
+visibility: public
+
+timeouts:
+  job:
+    minutes: 5
+  action:
+    minutes: 1
+  connection:
+    minutes: 2
+    
+actions:
+- deploy:
+    timeout:
+      minutes: 4
+    to: ssh
+- boot:
+    method: ssh
+    connection: ssh
+    prompts: ["root@RevPi"]
+    timeout:
+      minutes: 2
+
+- test:
+    timeout:
+      minutes: 5
+    definitions:
+    - repository:
+        metadata:
+          format: Lava-Test Test Definition 1.0
+          name: worker-device-test
+          description: "Simple test if the test will be executed on given devices on a specific worker"
+        run:
+          steps:
+          - lava-test-case test1-pass --result pass
+          - lava-test-case test2-pass --result pass
+      from: inline
+      name: worker-device-test
+      path: inline/worker-device-test.yaml

--- a/automated/health-checks/health-check_RevPi_Core.yaml
+++ b/automated/health-checks/health-check_RevPi_Core.yaml
@@ -10,32 +10,34 @@ timeouts:
     minutes: 1
   connection:
     minutes: 2
-    
+
 actions:
 - deploy:
     timeout:
-      minutes: 4
+      # this is a health check, so no flashing or other time-intensive tasks
+      # need to be executed
+      minutes: 1
     to: ssh
+
 - boot:
     method: ssh
     connection: ssh
-    prompts: ["root@RevPi"]
+    # it is assumed that the revpi is in a working state for the health check,
+    # so the prompt should be set correctly (i.e. the hostname is correct)
+    prompts: ["root@RevPi[0-9]+:"]
     timeout:
-      minutes: 2
+      minutes: 1
 
 - test:
     timeout:
-      minutes: 5
+      # the actual test for the health check is very basic and tests for dmesg
+      # warnings or errors, cpu load, free memory, free disk space, and
+      # internet connectivity. this should be doable in 1 minute
+      minutes: 1
     definitions:
-    - repository:
-        metadata:
-          format: Lava-Test Test Definition 1.0
-          name: worker-device-test
-          description: "Simple test if the test will be executed on given devices on a specific worker"
-        run:
-          steps:
-          - lava-test-case test1-pass --result pass
-          - lava-test-case test2-pass --result pass
-      from: inline
-      name: worker-device-test
-      path: inline/worker-device-test.yaml
+    - name: health-check-test
+      repository: https://github.com/RevolutionPi/LAVA-test-definitions.git
+      from: git
+      path: automated/health-checks/tests/health-check-test.yaml
+      params:
+        DUT: "Core"

--- a/automated/health-checks/tests/health-check-test.yaml
+++ b/automated/health-checks/tests/health-check-test.yaml
@@ -1,0 +1,26 @@
+metadata:
+    name: Test Health Check
+    format: "Lava-Test Test Definition 1.0"
+    description: "Standard Health Check for RevPi devices"
+    maintainer:
+        - r.gsponer@kunbus.com
+    os:
+        - raspian
+    scope:
+        - functional
+    devices:
+        - Core
+        - Core 3
+        - core 3+
+        - Core S
+        - Core SE
+        - Connect
+        - Connect+
+        - Connect S
+        - Connect SE
+        - Compact
+        - Flat
+run:
+    steps:
+        - cd automated/health-checks/tests
+        - bash ./health-check.sh "${DUT}"

--- a/automated/health-checks/tests/health-check.sh
+++ b/automated/health-checks/tests/health-check.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+TEST_CASE_NAME=$(basename "$0" .sh)
+
+# Check CPU load
+cpu_load=$(uptime | awk -F 'load average:' '{print $2}' | awk -F, '{print $1}' | awk '{$1=$1};1')
+echo "CPU Load: $cpu_load"
+
+# Check available memory
+free_mem=$(free -m | awk 'NR==2{printf "%.2f%%", $3*100/$2}')
+echo "Available Memory: $free_mem"
+
+# Check disk space
+disk_space=$(df -h / | awk 'NR==2{printf "%s", $5}')
+echo "Disk Space: $disk_space"
+
+lava-test-case "$TEST_CASE_NAME-Health-Check" --result pass


### PR DESCRIPTION
A health check is a special type of test job, designed to validate that the test device and the infrastructure around it are suitable for running LAVA tests.

Health checks jobs are run periodically to check for equipment and/or infrastructure failures that may have happened. If a health check fails for any device, that device will be automatically taken offline.
Reports are available which show these failures and track the general health of the lab.

The files had not been documented until now.
They are now added to the repository and were also updated.