### PR TITLE
feat: Create job to flash and test image with LAVA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# LAVA-test-definitions
-A set of testing scripts designed to work with LAVA.

--- a/automated/linux/jobs-definition/connect/job-PT-1.yaml
+++ b/automated/linux/jobs-definition/connect/job-PT-1.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Connect
+device_type: RevPi_Connect
 job_name: Test PT-1 - Connect
 priority: medium
 visibility: public

--- a/automated/linux/jobs-definition/connect/job-eth-ethtool.yaml
+++ b/automated/linux/jobs-definition/connect/job-eth-ethtool.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Connect
+device_type: RevPi_Connect
 job_name: Test eth-ethtool - Connect
 priority: medium
 visibility: public

--- a/automated/linux/jobs-definition/connect/job-eth-iperf3.yaml
+++ b/automated/linux/jobs-definition/connect/job-eth-iperf3.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Connect
+device_type: RevPi_Connect
 job_name: Test eth-iperf3 - Connect
 priority: medium
 visibility: public

--- a/automated/linux/jobs-definition/connect/job-leds1.yaml
+++ b/automated/linux/jobs-definition/connect/job-leds1.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Connect
+device_type: RevPi_Connect
 job_name: Test LEDs 1 - Check LEDs with visual test - LEDs on/off - green/red."
 priority: medium
 visibility: public

--- a/automated/linux/jobs-definition/connect/job-usb-2.yaml
+++ b/automated/linux/jobs-definition/connect/job-usb-2.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Connect
+device_type: RevPi_Connect
 job_name: Test USB data transfer with USB flash disk - Connect
 priority: medium
 visibility: public

--- a/automated/linux/jobs-definition/connect/job-usb-3.yaml
+++ b/automated/linux/jobs-definition/connect/job-usb-3.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Connect
+device_type: RevPi_Connect
 job_name: Test read speed from USB flash disk - Connect
 priority: medium
 visibility: public

--- a/automated/linux/jobs-definition/connect/job-usb-4.yaml
+++ b/automated/linux/jobs-definition/connect/job-usb-4.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Connect
+device_type: RevPi_Connect
 job_name: Test write speed from USB flash disk - Connect
 priority: medium
 visibility: public

--- a/automated/linux/jobs-definition/core/job-PT-1.yaml
+++ b/automated/linux/jobs-definition/core/job-PT-1.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Core
+device_type: RevPi_Core
 job_name: Test PT-1 - Core
 priority: medium
 visibility: public

--- a/automated/linux/jobs-definition/core/job-eth-ethtool.yaml
+++ b/automated/linux/jobs-definition/core/job-eth-ethtool.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Core
+device_type: RevPi_Core
 job_name: Test eth-ethtool - Core
 priority: medium
 visibility: public

--- a/automated/linux/jobs-definition/core/job-eth-iperf3.yaml
+++ b/automated/linux/jobs-definition/core/job-eth-iperf3.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Core
+device_type: RevPi_Core
 job_name: Test eth-iperf3 - Core
 priority: medium
 visibility: public

--- a/automated/linux/jobs-definition/core/job-leds1.yaml
+++ b/automated/linux/jobs-definition/core/job-leds1.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Core
+device_type: RevPi_Core
 job_name: Test LEDs 1 - Check LEDs with visual test - LEDs on/off - green/red."
 priority: medium
 visibility: public

--- a/automated/linux/jobs-definition/core/job-usb-2.yaml
+++ b/automated/linux/jobs-definition/core/job-usb-2.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Core
+device_type: RevPi_Core
 job_name: Test USB data transfer with USB flash disk - Core
 priority: medium
 visibility: public

--- a/automated/linux/jobs-definition/core/job-usb-3.yaml
+++ b/automated/linux/jobs-definition/core/job-usb-3.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Core
+device_type: RevPi_Core
 job_name: Test read speed from USB flash disk - Core
 priority: medium
 visibility: public

--- a/automated/linux/jobs-definition/core/job-usb-4.yaml
+++ b/automated/linux/jobs-definition/core/job-usb-4.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Core
+device_type: RevPi_Core
 job_name: Test write speed from USB flash disk - Core
 priority: medium
 visibility: public

--- a/automated/linux/jobs-definition/job-0001_test-repo.yaml
+++ b/automated/linux/jobs-definition/job-0001_test-repo.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Core
+device_type: RevPi_Core
 job_name: Core3 - First job from GitHub Repository
 priority: medium
 visibility: public

--- a/automated/linux/jobs-definition/job-0002_test-repo-script.yaml
+++ b/automated/linux/jobs-definition/job-0002_test-repo-script.yaml
@@ -1,4 +1,4 @@
-device_type:	RevPi_Core
+device_type: RevPi_Core
 job_name: RevPi_Core - Job from GitHub RevolutionPi Repository with single shell script
 priority: medium
 visibility: public

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,61 @@
+# prepare_lava_job
+
+prepare_lava_job is a Python script designed to generate Job files in YAML format. These job files are designed to be used with LAVA in order to automate the process of flashing and testing RevPi devices, thus saving time in identifying errors in the images.
+
+Once the LAVA Job has been generated, it can be submitted using one of the following methods:
+- lavacli command-line tool
+- LAVA webUI
+- LAVA REST/XML-RPC API
+
+Please refer to the LAVA documentation for detailed instructions on how to submit the generated job. For a example using lavacli, see the "Example" section.
+
+## Features
+
+- Generates LAVA Job files for flashing and testing images on RevPi devices.
+- Allows customization of job parameters through command-line arguments.
+
+## Usage
+
+The LAVA Job Generator can be executed using the following command:
+
+- -d, --device-type: Specify the device type to use for testing.
+- -u, --url: Provide the URL of the image to be flashed.
+- --flash: Specify the manifest used to flash the given image onto the DUT (required).
+- -s, --testsuite: Specify the job testsuite to be used after flashing (required).
+- -t, --tags: Specify the tag used for selecting an appropriate device for testing.
+
+> **_NOTE_** The default values used are taken from the Job created to flash the device. An example (and a recommendation) of a Job used for flashing devices can be found here: [../automated/deployment/job-flash-RevPi_Core.yaml](../automated/deployment/job-flash-RevPi_Core.yaml).
+
+> **_NOTE_** By using the recommended Job:
+
+> - the generated job is configured for a RevPi Core device (device_type: RevPi_Core) and uses the "config_core_01" tag.
+
+> - the image is "2023-06-26-revpi-bullseye-rc3-arm64-lite.img". 
+
+---
+> **_NOTE:_**  This behavior can be modified by providing appropriate options.
+---
+
+- A default job used to flash the image can be found here: [../automated/deployment/job-flash-RevPi_Core.yaml](../automated/deployment/job-flash-RevPi_Core.yaml)
+
+- A testsuite with a compilation of tests for RevPi Core devices can be found here: [../automated/testsuites/core-testsuite-001.yml](../automated/testsuites/core-testsuite-001.yml)
+
+---
+
+For more information, please consult the LAVA documentation and the examples provided in this repository.
+
+### Example
+
+Example using job-flash-RevPi_Core.yaml to flash device and then running a testsuite for Core devices, saving the Job in `/tmp/job.yaml`
+```
+./prepare_lava_job --flash ../automated/deployment/job-flash-RevPi_Core.yaml -s ../automated/testsuites/core-testsuite-001.yml > /tmp/job.yaml
+```
+
+#### Submitting the Job using lavacli
+```
+lavacli jobs submit /tmp/job.yaml
+```
+
+### Contributing
+
+Contributions are welcome! If you have any suggestions, bug reports, or feature requests, please create an issue in this repository.

--- a/tools/prepare_lava_job
+++ b/tools/prepare_lava_job
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+This script is designed to generate a LAVA Job-file in yaml, which
+can be used with our RevPi devices in order to flash and perform tests
+with LAVA automatically, thus saving time finding errors in the images.
+"""
+
+import argparse
+import os
+import sys
+import yaml
+
+parser = argparse.ArgumentParser(
+    description=__doc__,
+    epilog="Default behaviour: Generate a LAVA Job to flash and run tests on a given RevPi device.",
+)
+
+parser.add_argument(
+    "-d",
+    "--device-type",
+    dest="device_type",
+    nargs="?",
+    help="Device type to use for testing",
+)
+
+parser.add_argument(
+    "-u",
+    "--url",
+    dest="url",
+    help="URL of the image to be flashed",
+)
+
+parser.add_argument(
+    "--flash",
+    dest="flash",
+    nargs="?",
+    required=True,
+    help="Manifest used to flash the given image onto the DUT",
+)
+
+parser.add_argument(
+    "-s",
+    "--testsuite",
+    dest="testsuite",
+    required=True,
+    help="Job testsuite to be used after flashing",
+)
+
+parser.add_argument(
+    "-t",
+    "--tags",
+    dest="tags",
+    type=str,
+    nargs="?",
+    const="True",
+    help="Tag used for selecting an appropriate device for testing",
+)
+
+# TODO what about another URLs???
+def get_image_name_from_url(url):
+    return os.path.basename(url)
+
+
+def add_namespace_in_testsuite(content):
+    actions = content.get("actions", [])
+
+    for action in actions:
+        if "test" in action or "boot" in action or "deploy" in action:
+            action_name = next(iter(action))
+            action[action_name]["namespace"] = "testsuite"
+
+    return content
+
+
+def create_job(device_type, device_tags, image_url, file_flash, file_testsuite) -> bool:
+    # Load the contents of file_flash
+    try:
+        with open(file_flash, "r") as file:
+            file_flash_contents = yaml.safe_load(file)
+    except OSError:
+        print(f"Could not read file to flash device: {file_flash}", file=sys.stderr)
+        return False
+    # Load the contents of file_testsuite
+    try:
+        with open(file_testsuite, "r") as file:
+            file_testsuite_contents = yaml.safe_load(file)
+    except OSError:
+        print(f"Could not read file with testsuite: {file_testsuite}", file=sys.stderr)
+        return False
+    if device_type:
+        # Update device_type
+        file_flash_contents["device_type"] = device_type
+
+    if not image_url:
+        image_url = file_flash_contents["actions"][2]["deploy"]["images"][
+            "recovery_image"
+        ]["url"]
+
+    # Update job_name
+    file_flash_contents["job_name"] = "Flash & Test Image: " + get_image_name_from_url(
+        image_url
+    )
+
+    if device_tags:
+        # Update device tags
+        file_flash_contents["tags"] = device_tags
+
+    if image_url:
+        # Update the image URL with the provided image parameter
+        file_flash_contents["actions"][2]["deploy"]["images"]["recovery_image"][
+            "url"
+        ] = image_url
+
+    # Append the actions from "file_testsuite" to the actions in "file_flash"
+    file_flash_contents["actions"].extend(file_testsuite_contents["actions"])
+
+    # Add or modify namespace from "file_testsuite"
+    file_testsuite_contents = add_namespace_in_testsuite(file_testsuite_contents)
+
+    # Output updated contents to stdout with proper indentation
+    formatted_output = yaml.dump(file_flash_contents, default_flow_style=False)
+    print(formatted_output)
+
+    return True
+
+
+def main() -> int:
+    args = parser.parse_args()
+
+    device_type = args.device_type
+    image_url = args.url
+    file_flash = args.flash
+    file_testsuite = args.testsuite
+    device_tags = args.tags
+
+    return int(
+        not create_job(device_type, device_tags, image_url, file_flash, file_testsuite)
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
feat: Create job to flash and test image with LAVA

"prepare_lava_job" is a tool to generate LAVA Jobs automatically.
Jobs are generated to flash a RevPi device and then perform a series of
tests, which are defined in a yaml file and passed as a parameter.

The generated Job has some variables already defined by default, which
can be modified using parameters. In the default behavior, the
generated Job is ready to be executed in a RevPi_Core and in our
Testrack (device_type: RevPi_Core, tags: config_core_01).

Once the LAVA Job has been generated, it could be submitted with can be submitted with
lavacli, webUI or REST/XML-RPC API.

For more information on how to use this tool, please see the
README.md file.

---
README file is coming soon.